### PR TITLE
Fix device BOOTLOOP when multiple BMS connected and SOC average activated

### DIFF
--- a/src/BmsData.cpp
+++ b/src/BmsData.cpp
@@ -346,7 +346,7 @@ void setBmsChargePercentage(uint8_t devNr, uint8_t value)
       const int32_t lo = bmsData.bmsMinCellVoltage[devNr];
       const int32_t sdiff = (int32_t)u16_CellvoltSoc100-(int32_t)u16_CellvoltSoc0;
       const int32_t input = (((hi-(int32_t)u16_CellvoltSoc0)*hi)+(((int32_t)u16_CellvoltSoc100-hi)*lo))/(sdiff);
-      int32_t result = ((input - u16_CellvoltSoc0)*100)/sdiff;
+      const int32_t result = ((input - u16_CellvoltSoc0)*100)/sdiff;
 
       if(result < 0 || lo <= u16_CellvoltSoc0)
         value = 0;

--- a/src/BmsData.cpp
+++ b/src/BmsData.cpp
@@ -338,7 +338,9 @@ void setBmsChargePercentage(uint8_t devNr, uint8_t value)
       bo_SOC100CellvolHasBeenReached[devNr]=true;
       value=100;
     }
-    else if(u16_CellvoltSoc100>0 && u16_CellvoltSoc0>0){
+    else if((u16_CellvoltSoc0 > 0) &&
+            (u16_CellvoltSoc100 > u16_CellvoltSoc0)) // Prevents from divide-by-zero and implict verifies (u16_CellvoltSoc100 > 0)
+    {
       //Berechne SOC Linear
       const int32_t hi = bmsData.bmsMaxCellVoltage[devNr];
       const int32_t lo = bmsData.bmsMinCellVoltage[devNr];

--- a/src/Canbus.cpp
+++ b/src/Canbus.cpp
@@ -1221,7 +1221,11 @@ void sendCanMsg_355()
         }
       }
 
-      if(u8_lMultiBmsSocHandling==OPTION_MULTI_BMS_SOC_AVG) msgData.soc = (u16_avgSoc/u8_numberOfSocs);
+      if ((u8_numberOfSocs > 0) && // Prevents from divide-by-zero
+          (u8_lMultiBmsSocHandling==OPTION_MULTI_BMS_SOC_AVG))
+      {
+        msgData.soc = (u16_avgSoc / u8_numberOfSocs);
+      }
     }
     else if(u8_lMultiBmsSocHandling==OPTION_MULTI_BMS_SOC_BMS) // Wenn SoC durch ein bestimmtes BMS geregelt werden soll
     {


### PR DESCRIPTION
Error description from Juergen @ Discord:

_Bei aktivieren des CAN Ports zum Deye Inverter und folgenden Neustart (oder Stromfrei-machen) hängt der BSC jedes mal im Bootloop. Die rote LED am NodeMCU blinkt alle 20-30 sec einmal auf. Das Gerät tauch nicht mehr im Wifi auf, auch nicht das Backup BSC Wifi. Schaut für mich wirklich nach Bootloop aus._

I could reproduce the error as follows:
- Simulated CAN communication of Inverter (just listening)
- Enabled BMS Canbus
- Set Data source master
- Added additional data source (no real devices connected)
- SoC Mittelwert

![grafik](https://github.com/shining-man/bsc_fw/assets/125823713/48942132-0ec6-46f2-bb23-8a0c0cea1f29)

Error log:
![grafik](https://github.com/shining-man/bsc_fw/assets/125823713/886f8884-1eac-45ae-9287-737aa3c70e68)


**NOTE:** Additionally I found another place, where a division-by-zero could occur. I fixed it as well, but this not verifiable without hardware.