### PR TITLE
Bugfix: unnötige writeConfig() Aufrufe beim Start

### DIFF
--- a/src/WebSettings.cpp
+++ b/src/WebSettings.cpp
@@ -210,7 +210,13 @@ void WebSettings::initWebSettings(const char *parameter, String confName, String
     readConfig();
   }
   getDefaultValuesFromNewKeys(parameterFile, 8);
-  if(bo_hasNewKeys) writeConfig();
+
+  if(bo_hasNewKeys) 
+  {
+    writeConfig();
+    bo_hasNewKeys = false;
+  }
+
   #ifdef WEBSET_DEBUG
   BSC_LOGI(TAG, "initWebSettings() end");
   #endif
@@ -681,7 +687,7 @@ void WebSettings::getDefaultValuesFromNewKeys(const char *parameter, uint32_t js
         retStr_default="";
         json.getValue(parameter, a, "default", jsonStartPos, retStr_default, u32_tmp);
 
-        if(isKeyExist(jsonName, u8_dataType)==false)
+        if((jsonNameBase!= 0) && (isKeyExist(jsonName, u8_dataType)==false))
         {
           bo_hasNewKeys=true;
           uint16_t id=0;
@@ -693,7 +699,7 @@ void WebSettings::getDefaultValuesFromNewKeys(const char *parameter, uint32_t js
       }
       else
       {
-        if(prefs.isKey(String(jsonName).c_str())==false)
+        if((jsonNameBase != 0) && (prefs.isKey(String(jsonName).c_str())==false))
         {
           bo_hasNewKeys=true;
           retStr_default="";


### PR DESCRIPTION
Vermeide unnötige writeConfig() Aufrufe durch:
1. Einträge die kein 'name' Attribut haben
2. fehlendes Rücksetzen von bo_hasNewKeys