### PR TITLE
Get rid of expensive copies caused by passing objects by value

### DIFF
--- a/include/webUtility.h
+++ b/include/webUtility.h
@@ -9,7 +9,7 @@
 #include <Arduino.h>
 #include <WebServer.h>
 
-bool handleFileRead(WebServer *server, bool fsIsSpiffs, String path);
-void handleFileUpload(WebServer *server, bool fsIsSpiffs, String fileName);
+bool handleFileRead(fs::FS &fs, WebServer &server, bool fsIsSpiffs, const String &path);
+void handleFileUpload(WebServer &server, bool fsIsSpiffs, const String &fileName);
 
 #endif

--- a/include/webUtility.h
+++ b/include/webUtility.h
@@ -10,6 +10,6 @@
 #include <WebServer.h>
 
 bool handleFileRead(fs::FS &fs, WebServer &server, bool fsIsSpiffs, const String &path);
-void handleFileUpload(WebServer &server, bool fsIsSpiffs, const String &fileName);
+void handleFileUpload(fs::FS &fs, WebServer &server, bool fsIsSpiffs, const String &fileName);
 
 #endif

--- a/lib/bsc/fs/FileGuard.hpp
+++ b/lib/bsc/fs/FileGuard.hpp
@@ -1,0 +1,81 @@
+// Copyright (c) 2024 Meik Jäckle
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+
+#ifndef FS_FILECLOSEGUARD_H
+#define FS_FILECLOSEGUARD_H
+
+#include <FS.h>
+
+/** The FileGuard uses the RAII programming techinque to open a file on instantiation of the FileGuard object
+ *  and closes it on scope exit. The file does not have to be closed manually.
+ *  It can be used as follows:
+ *  @code
+ *  {
+ *    fs::FileGuard fileGuard(fs, "index.htm", "r"); // RAII: Open the file in the file system fs
+ *    if (fileGuard.isFileOpen())
+ *    {
+ *      const char* text = "Example text";
+ *      fileGuard.getFile().write(text, sizeof(text));
+ *    }
+ *  } // Note: File is closed in scope exit!
+ *
+ *  @endcode
+*/
+namespace fs
+{
+
+class FileGuard
+{
+  // Do not allow to copy this class
+  public:
+  FileGuard(const FileGuard&) = delete;
+  FileGuard& operator=(const FileGuard&) = delete;
+
+  public:
+  /** Dtor opens a file on the given file path.
+   *  @param[in] fs The files system on which the file must be opened
+   *  @param[in] path The file path
+   *  @param[in] mode Open mode
+   *  @param[in] create On true the file will be created if it does not exist.
+   *
+   *  @note For parameter details see documentation of fs::FS.
+  */
+  FileGuard(fs::FS& fs, const String& path, const char* mode = FILE_READ, const bool create = false)
+    : _file(std::move(fs.open(path, mode, create)))
+  {}
+
+  /**
+   * Dtor closes the file.
+  */
+  ~FileGuard()
+  {
+    _file.close();
+  }
+
+  /**
+   * Returns the reference to the opened file.
+  */
+  File& getFile() noexcept
+  {
+    return _file;
+  }
+
+  /**
+   * Returns true, if the file was successfully opened and it is a file not a directory.
+  */
+  bool isFile() const
+  {
+    // We have to const_cast the _file, be const isDirectory is not const qualified, but it should.
+    return (true == _file) && (!const_cast<File&>(_file).isDirectory());
+  }
+
+  private:
+  fs::File _file;
+};
+
+} // namespace fs
+
+#endif // FS_FILECLOSEGUARD_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1339,11 +1339,11 @@ void setup()
   server.on("/uploadPbnFw", HTTP_POST, sendResponceUpdateBpnFw, [](){handleFileUpload(&server, true, "bpnFw.bin");});
   #endif
 
-  server.on("/log", HTTP_GET, []() {if(!handleFileRead(&server, true, "/log.txt")){server.send(404, "text/plain", "FileNotFound");}});
-  server.on("/log1", HTTP_GET, []() {if(!handleFileRead(&server, true, "/log1.txt")){server.send(404, "text/plain", "FileNotFound");}});
-  server.on("/trigger", HTTP_GET, []() {if(!handleFileRead(&server, true, "/trigger.txt")){server.send(404, "text/plain", "FileNotFound");}});
-  server.on("/valueslog", HTTP_GET, []() {if(!handleFileRead(&server, true, "/values")){server.send(404, "text/plain", "FileNotFound");}});
-  //server.on("/param", HTTP_GET, []() {if(!handleFileRead(&server, false, "/WebSettings.conf")){server.send(404, "text/plain", "FileNotFound");}});
+  server.on("/log", HTTP_GET, []() {if(!handleFileRead(SPIFFS, server, true, "/log.txt")){server.send(404, "text/plain", "FileNotFound");}});
+  server.on("/log1", HTTP_GET, []() {if(!handleFileRead(SPIFFS, server, true, "/log1.txt")){server.send(404, "text/plain", "FileNotFound");}});
+  server.on("/trigger", HTTP_GET, []() {if(!handleFileRead(SPIFFS, server, true, "/trigger.txt")){server.send(404, "text/plain", "FileNotFound");}});
+  server.on("/valueslog", HTTP_GET, []() {if(!handleFileRead(SPIFFS, server, true, "/values")){server.send(404, "text/plain", "FileNotFound");}});
+  //server.on("/param", HTTP_GET, []() {if(!handleFileRead(SPIFFS, server, false, "/WebSettings.conf")){server.send(404, "text/plain", "FileNotFound");}});
 
   otaUpdater.init(&server, "/settings/webota/", true);
 

--- a/src/webUtility.cpp
+++ b/src/webUtility.cpp
@@ -16,7 +16,7 @@
 #include <fs/FileGuard.hpp>
 #include <WebServer.h>
 
-namespace // anonymous - methods, variables, and types in this namespace are have file scope only
+namespace // anonymous namespace - methods, variables, and types in this namespace have file scope only
 {
 
 const char * TAG = "WEB";
@@ -79,7 +79,7 @@ bool handleFileRead(fs::FS &fs, WebServer &server, [[maybe_unused]] bool fsIsSpi
   return false;
 }
 
-void handleFileUpload(WebServer &server, [[maybe_unused]] bool fsIsSpiffs, const String &fileName)
+void handleFileUpload(fs::FS &fs, WebServer &server, [[maybe_unused]] bool fsIsSpiffs, const String &fileName)
 {
   static File fsUploadFile;
   HTTPUpload& upload = server.upload();
@@ -91,7 +91,7 @@ void handleFileUpload(WebServer &server, [[maybe_unused]] bool fsIsSpiffs, const
     //}
     upload.filename = fileName;
     BSC_LOGI(TAG,"handleFileUpload Name: /%s", upload.filename.c_str());
-    fsUploadFile = SPIFFS.open("/" + server.urlDecode(upload.filename), "w");
+    fsUploadFile = fs.open("/" + server.urlDecode(upload.filename), "w");
   }
   else if (upload.status == UPLOAD_FILE_WRITE)
   {


### PR DESCRIPTION
The main reason for this PR was to get rid of the expensive deep copies of strings passing by value. (I just started with this module, as it is the shortest. I will update the others as well.)
Additionally I refactored the module a bit. 
Following are the main changes:
- Pass string by const reference
- Pass WebServer by reference, not by pointer (this not a performance improvement, but by using references we do not have to take care for nullptr.)
- Add the file system object as reference instead of using the global instance (keyword: dependency injection).
- Added the FileGuard class, which automatically closes a file when going out of scope by using the RAII (Resource acquisition is initialization) idiom. At least, the `fs::File` class takes already care to close the file, when the last copy of the file handle is deleted. With the `FileGuard` you have more control, when file use in a local scope is close without calling the `close()` method manually. Additionally it provides a method to verify if the file was opened successfully.
