### PR TITLE
CRITICAL: Prevent Remote Stack Buffer Overflow in WebSettings

### DIFF
--- a/src/WebSettings.cpp
+++ b/src/WebSettings.cpp
@@ -1784,43 +1784,74 @@ void WebSettings::setPreferencesU32(const char* name, uint32_t val)
 
 
 #ifdef INSIDER_V1
-void addJsonElem(char *buf, int id, bool val)
+
+
+void addJsonElem(char *buf, size_t max_len, int id, bool val)
 {
-  uint16_t bufLen = strlen(buf);
-  if (bufLen == 0) sprintf(&buf[bufLen], "[");
-  else sprintf(&buf[bufLen], ",");
-  bufLen++;
-  sprintf(&buf[bufLen], "{\"id\":%i, \"val\":%u}",id,val);
+  size_t bufLen = strlen(buf);
+  if (bufLen >= max_len - 1) return;
+
+  if (bufLen == 0) snprintf(&buf[bufLen], max_len - bufLen, "[");
+  else snprintf(&buf[bufLen], max_len - bufLen, ",");
+  
+  bufLen = strlen(buf);
+  if (bufLen >= max_len - 1) return;
+  
+  snprintf(&buf[bufLen], max_len - bufLen, "{\"id\":%i, \"val\":%u}",id,val);
 }
-void addJsonElem(char *buf, int id, int32_t val)
+
+
+void addJsonElem(char *buf, size_t max_len, int id, int32_t val)
 {
-  uint16_t bufLen = strlen(buf);
-  if (bufLen == 0) sprintf(&buf[bufLen], "[");
-  else sprintf(&buf[bufLen], ",");
-  bufLen++;
-  sprintf(&buf[bufLen], "{\"id\":%i, \"val\":%i}",id,val);
+  size_t bufLen = strlen(buf);
+  if (bufLen >= max_len - 1) return;
+
+  if (bufLen == 0) snprintf(&buf[bufLen], max_len - bufLen, "[");
+  else snprintf(&buf[bufLen], max_len - bufLen, ",");
+  
+  bufLen = strlen(buf);
+  if (bufLen >= max_len - 1) return;
+  
+  snprintf(&buf[bufLen], max_len - bufLen, "{\"id\":%i, \"val\":%i}",id,val);
 }
-void addJsonElem(char *buf, int id, float val)
+
+
+void addJsonElem(char *buf, size_t max_len, int id, float val)
 {
-  uint16_t bufLen = strlen(buf);
-  if (bufLen == 0) sprintf(&buf[bufLen], "[");
-  else sprintf(&buf[bufLen], ",");
-  bufLen++;
-  sprintf(&buf[bufLen], "{\"id\":%i, \"val\":%.3f}",id,val);
+  size_t bufLen = strlen(buf);
+  if (bufLen >= max_len - 1) return;
+
+  if (bufLen == 0) snprintf(&buf[bufLen], max_len - bufLen, "[");
+  else snprintf(&buf[bufLen], max_len - bufLen, ",");
+  
+  bufLen = strlen(buf);
+  if (bufLen >= max_len - 1) return;
+  
+  snprintf(&buf[bufLen], max_len - bufLen, "{\"id\":%i, \"val\":%.3f}",id,val);
 }
-void addJsonElem(char *buf, int id, String val)
+
+void addJsonElem(char *buf, size_t max_len, int id, String val)
 {
-  uint16_t bufLen = strlen(buf);
-  if (bufLen == 0) sprintf(&buf[bufLen], "[");
-  else sprintf(&buf[bufLen], ",");
-  bufLen++;
-  sprintf(&buf[bufLen], "{\"id\":%i, \"val\":\"%s\"}",id,val.c_str());
+  size_t bufLen = strlen(buf);
+  if (bufLen >= max_len - 1) return;
+
+  if (bufLen == 0) {
+	  snprintf(&buf[bufLen], max_len - bufLen, "[");
+  } else {
+	  snprintf(&buf[bufLen], max_len - bufLen, ",");
+  }
+  
+  bufLen = strlen(buf);
+  if (bufLen >= max_len - 1) return;
+  
+  snprintf(&buf[bufLen], max_len - bufLen, "{\"id\":%i, \"val\":\"%s\"}", id, val.c_str());
 }
 
 void WebSettings::handleGetValues(WebServer *server)
 {
   uint32_t argName;
   char data[4096] = { 0 };
+  size_t max_len = sizeof(data);
   //BSC_LOGI(TAG,"handleGetValues: args=%i",server->args());
   for(uint8_t i=0; i<server->args(); i++)
   {
@@ -1835,17 +1866,17 @@ void WebSettings::handleGetValues(WebServer *server)
 
       if(u8_storeInFlash==0)
       {
-        if(u8_dataType==PARAM_DT_BO) addJsonElem(data, argName, getBool((uint16_t)(argName&0xFFFF)));
-        else if(u8_dataType==PARAM_DT_FL) addJsonElem(data, argName, getFloat((uint16_t)(argName&0xFFFF)));
-        else if(u8_dataType==PARAM_DT_ST) addJsonElem(data, argName, getString((uint16_t)(argName&0xFFFF),false,PARAM_DT_ST));
-        else addJsonElem(data, argName, getInt((uint16_t)(argName&0xFFFF), u8_dataType));
+        if(u8_dataType==PARAM_DT_BO) addJsonElem(data, max_len, argName, getBool((uint16_t)(argName&0xFFFF)));
+        else if(u8_dataType==PARAM_DT_FL) addJsonElem(data, max_len, argName, getFloat((uint16_t)(argName&0xFFFF)));
+        else if(u8_dataType==PARAM_DT_ST) addJsonElem(data, max_len, argName, getString((uint16_t)(argName&0xFFFF),false,PARAM_DT_ST));
+        else addJsonElem(data, max_len, argName, getInt((uint16_t)(argName&0xFFFF), u8_dataType));
       }
       else if(u8_storeInFlash==1)
       {
-        if(u8_dataType==PARAM_DT_BO) addJsonElem(data, argName, getBoolFlash((uint16_t)(argName&0xFFFF)));
-        else if(u8_dataType==PARAM_DT_FL) addJsonElem(data, argName, getFloatFlash((uint16_t)(argName&0xFFFF)));
-        else if(u8_dataType==PARAM_DT_ST) addJsonElem(data, argName, getStringFlash((uint16_t)(argName&0xFFFF)));
-        else addJsonElem(data, argName, (int)getIntFlash((uint16_t)(argName&0xFFFF), u8_dataType));
+        if(u8_dataType==PARAM_DT_BO) addJsonElem(data, max_len, argName, getBoolFlash((uint16_t)(argName&0xFFFF)));
+        else if(u8_dataType==PARAM_DT_FL) addJsonElem(data, max_len, argName, getFloatFlash((uint16_t)(argName&0xFFFF)));
+        else if(u8_dataType==PARAM_DT_ST) addJsonElem(data, max_len, argName, getStringFlash((uint16_t)(argName&0xFFFF)));
+        else addJsonElem(data, max_len, argName, (int)getIntFlash((uint16_t)(argName&0xFFFF), u8_dataType));
       }
     }
     else
@@ -1853,7 +1884,10 @@ void WebSettings::handleGetValues(WebServer *server)
       BSC_LOGE(TAG,"handleGetValues: not number");
     }
   }
-  sprintf(&data[strlen(data)], "]");
+  size_t current_len = strlen(data);
+  if (current_len < max_len -2) {
+	  snprintf(&data[current_len], max_len - current_len, "]");
+  }
 
   server->send(200, "application/json", data);
 }
@@ -1944,13 +1978,3 @@ void WebSettings::handleSetValues(WebServer *server)
   server->send(200, "application/json", "{\"state\":1}");
 }
 #endif
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
### Bug: Stack-based Buffer Overflow in `addJsonElem` via Unbounded `sprintf` (CWE-121)

**Impact:**
The `handleGetValues` function allocates a fixed-size 4096-byte buffer (`char data[4096]`) on the stack and iteratively passes it to overloaded `addJsonElem` functions for each HTTP request argument parsed from `server->args()`. The `addJsonElem` functions use `strlen(buf)` to find the end of the string and append JSON key-value pairs using `sprintf` without verifying the remaining buffer capacity. 

An attacker can supply a crafted HTTP request containing an excessive number of query parameters. Because the loop processes all provided arguments and blindly appends to `data`, the appended payload will eventually exceed the 4096-byte limit. This results in a stack-based buffer overflow, overwriting adjacent stack memory. The immediate impact is a Denial of Service (device crash/watchdog reset), with potential for Remote Code Execution (RCE) depending on the underlying RTOS/firmware stack layout and exploit mitigations.

**Vulnerable Code:**
```c
void addJsonElem(char *buf, int id, bool val)
{
  uint16_t bufLen = strlen(buf);
  if (bufLen == 0) sprintf(&buf[bufLen], "[");
  else sprintf(&buf[bufLen], ",");
  bufLen++;
  sprintf(&buf[bufLen], "{\"id\":%i, \"val\":%u}",id,val);
}

// ... (other overloaded addJsonElem functions share the same flaw) ...

void WebSettings::handleGetValues(WebServer *server)
{
  uint32_t argName;
  char data[4096] = { 0 };
  
  for(uint8_t i=0; i<server->args(); i++)
  {
    if(isNumber(server->argName(i))) 
    {
      argName = server->argName(i).toInt();
      // ...
      if(u8_storeInFlash==0)
      {
        if(u8_dataType==PARAM_DT_BO) addJsonElem(data, argName, getBool((uint16_t)(argName&0xFFFF)));
        // ...
```

**Proposed Fix:**
Refactor the `addJsonElem` overloads to accept a maximum buffer size parameter and replace `sprintf` with `snprintf` to enforce strict bounds checking. Update `handleGetValues` to pass `sizeof(data)` and safely append the closing bracket.

```c
// Apply this pattern to all addJsonElem overloads
void addJsonElem(char *buf, size_t max_len, int id, bool val)
{
  size_t bufLen = strlen(buf);
  if (bufLen >= max_len - 1) return; // Buffer full, drop payload
  
  int written = snprintf(&buf[bufLen], max_len - bufLen, (bufLen == 0) ? "[" : ",");
  if (written > 0 && (size_t)written < max_len - bufLen) {
      bufLen += written;
  } else {
      return; // Truncation occurred
  }
  
  snprintf(&buf[bufLen], max_len - bufLen, "{\"id\":%i, \"val\":%u}", id, val);
}

// ... update other addJsonElem signatures similarly ...

void WebSettings::handleGetValues(WebServer *server)
{
  uint32_t argName;
  char data[4096] = { 0 };
  const size_t max_len = sizeof(data);
  
  for(uint8_t i=0; i<server->args(); i++)
  {
    if(isNumber(server->argName(i))) 
    {
      argName = server->argName(i).toInt();
      uint8_t u8_storeInFlash = ((argName>>16)&0xff);
      uint8_t u8_dataType = ((argName>>24)&0xff);

      if(u8_storeInFlash==0)
      {
        if(u8_dataType==PARAM_DT_BO) addJsonElem(data, max_len, argName, getBool((uint16_t)(argName&0xFFFF)));
        else if(u8_dataType==PARAM_DT_FL) addJsonElem(data, max_len, argName, getFloat((uint16_t)(argName&0xFFFF)));
        else if(u8_dataType==PARAM_DT_ST) addJsonElem(data, max_len, argName, getString((uint16_t)(argName&0xFFFF),false,PARAM_DT_ST));
        else addJsonElem(data, max_len, argName, getInt((uint16_t)(argName&0xFFFF), u8_dataType));
      }
      else if(u8_storeInFlash==1)
      {
        if(u8_dataType==PARAM_DT_BO) addJsonElem(data, max_len, argName, getBoolFlash((uint16_t)(argName&0xFFFF)));
        else if(u8_dataType==PARAM_DT_FL) addJsonElem(data, max_len, argName, getFloatFlash((uint16_t)(argName&0xFFFF)));
        else if(u8_dataType==PARAM_DT_ST) addJsonElem(data, max_len, argName, getStringFlash((uint16_t)(argName&0xFFFF)));
        else addJsonElem(data, max_len, argName, (int)getIntFlash((uint16_t)(argName&0xFFFF), u8_dataType));
      }
    }
    else
    {
      BSC_LOGE(TAG,"handleGetValues: not number");
    }
  }
  
  size_t current_len = strlen(data);
  if (current_len < max_len - 1) {
      snprintf(&data[current_len], max_len - current_len, "]");
  }

  server->send(200, "application/json", data);
}
```